### PR TITLE
Correct fatal error in plugin.php line 129

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -126,6 +126,9 @@ function impress_agents_init() {
 
 	add_action( 'widgets_init', 'impress_agents_register_widgets' );
 
+        /** Make sure is_plugin_active() can be called */
+        include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
 	if(is_plugin_active('genesis-agent-profiles/plugin.php')) {
 		add_action( 'wp_loaded', 'impress_agents_migrate' );
 	}


### PR DESCRIPTION
Added include_once( ABSPATH . ‘wp-admin/includes/plugin.php’ ); to correct for fatal error

Fatal error: Call to undefined function is_plugin_active() in /Users/loneduchess/Documents/Websites/www.sablighrealestate.dev/wp-content/plugins/impress-agents/plugin.php on line 129
