### PR TITLE
add sortable key to p2p connection type

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -32,7 +32,8 @@ function impa_employee_connection_types() {
     p2p_register_connection_type( array(
         'name' => 'agents_to_listings',
         'from' => 'employee',
-        'to' => 'listing'
+        'to' => 'listing',
+        'sortable' => 'any'
     ) );
 }
 


### PR DESCRIPTION
add sortable key to p2p connection type agents_to_listings in order to sort the agents connected to a property for display and query purposes
